### PR TITLE
Use more portable filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Simple script for pulling information from Lanyrd event and serializing them int
 python pyvo-pull.py "http://lanyrd.com/series/brno-pyvo/"
 ```
 
-Creates directory `Brněnské PyVo + BRUG`, which will contain files `2011-04-26 Poprve.yaml`, `2011-06-13 Druhé.yaml`, etc.
+Creates directory `brnenske-pyvo-brug`, which will contain files `2011-04-26-poprve.yaml`, `2011-06-13-druhe.yaml`, etc.
 
 ```
 python pyvo-pull.py "http://lanyrd.com/2015/brno-pyvo-april/"
 ```
 
-Creates file `2015-04-30 Freelancing.yaml`.
+Creates file `2015-04-30-freelancing.yaml`.
 
 ## Requirements
 

--- a/pyvo-pull.py
+++ b/pyvo-pull.py
@@ -3,11 +3,13 @@
 
 import os
 import sys
+import re
 
 import yaml
 import arrow
 import requests
 from lxml import html
+import unidecode
 
 
 def render_event(filename, event):
@@ -15,10 +17,20 @@ def render_event(filename, event):
         yaml.dump(event, f, default_flow_style=False, allow_unicode=True)
 
 
+def slugify(name):
+    """Make a filename-friendly approximation of a string
+
+    The result only uses the characters a-z, 0-9, _, -
+    """
+    decoded = unidecode.unidecode(name).lower()
+    return re.sub('[^a-z0-9_]+', '-', decoded).strip('-')
+
+
 def create_filename(event):
     date = event['start'][0:10]
-    if event['topic']:
-        return '{} {}.yaml'.format(date, event['topic'])
+    topic = event['topic']
+    if topic:
+        return '{}-{}.yaml'.format(date, slugify(topic))
     return '{}.yaml'.format(date)
 
 
@@ -149,7 +161,7 @@ if __name__ == '__main__':
 
     if '/series/' in url:
         series_name, events = pull_event_series(url)
-        output_dir = os.path.join(os.getcwd(), series_name)
+        output_dir = os.path.join(os.getcwd(), slugify(series_name))
         os.makedirs(output_dir, exist_ok=True)
     else:
         events = [pull_event(url)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ lxml==3.4.2
 python-dateutil==2.4.1
 requests==2.6.0
 six==1.9.0
+unidecode==0.04.17


### PR DESCRIPTION
Limit filenames to the character set [a-z0-9_-].

Mixing upper- and lowercase can be painful on case-sensitive filesystems
(which are common on portable drives, for example).
Non-ASCII characters are inconvenient to type on some devices.
Other special characters may need quoting in shells, or even
separate directories.
