### PR TITLE
Use yaml.safe_dump

### DIFF
--- a/pyvo-pull.py
+++ b/pyvo-pull.py
@@ -14,7 +14,7 @@ import unidecode
 
 def render_event(filename, event):
     with open(filename, 'w') as f:
-        yaml.dump(event, f, default_flow_style=False, allow_unicode=True)
+        yaml.safe_dump(event, f, default_flow_style=False, allow_unicode=True)
 
 
 def slugify(name):


### PR DESCRIPTION
Doesn't really matter in this case, but safe_dump/safe_load should
always be preferred unless one knows what they're doing.
