### PR TITLE
Scrape descriptions for talks

### DIFF
--- a/pyvo-pull.py
+++ b/pyvo-pull.py
@@ -154,7 +154,7 @@ def pull_event(url):
             split_text = re.split(' and |,', speaker_text)
             talkinfo['speakers'] = [t.strip() for t in split_text]
         for link in talk.cssselect('h3 a'):
-            add_coverage(talkinfo, link.attrib['href'])
+            scrape_talk_page(talkinfo, link.attrib['href'])
 
     # compose the final object
     eventinfo = collections.OrderedDict()
@@ -173,7 +173,7 @@ def pull_event(url):
     return eventinfo
 
 
-def add_coverage(talk, url):
+def scrape_talk_page(talk, url):
     talk['urls'] = [url]
     coverage = talk['coverage'] = []
 
@@ -192,6 +192,10 @@ def add_coverage(talk, url):
             }[cls]
         for link in item.cssselect('h3 a'):
             coverage.append({coverage_type: link.attrib['href']})
+
+    description = text(tree, '.description')
+    if description:
+        talk['description'] = description
 
 
 def scrape(url):


### PR DESCRIPTION
Lanyrd talks can have descriptions/info/abstracts! They're somewhat hidden, so the feature isn't used very much, but some Pyvo talks do have them: https://github.com/pyvec/pyvo-data/commit/4ffeb9f8e15041f9a6673eadf2127f76c0d74236
